### PR TITLE
Refacotr build.gradle

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,9 +1,6 @@
 apply plugin: 'com.android.application'
-
 apply plugin: 'kotlin-android'
-
 apply plugin: 'kotlin-android-extensions'
-
 apply plugin: 'kotlin-kapt'
 
 android {
@@ -27,14 +24,21 @@ android {
     }
 
     buildTypes {
-        staging {
+        debug {
             minifyEnabled false
+            debuggable true
+        }
+
+        staging {
+            minifyEnabled true
             debuggable true
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
             signingConfig signingConfigs.staging
         }
+
         release {
-            minifyEnabled false
+            minifyEnabled true
+            debuggable false
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,3 @@
-// Top-level build file where you can add configuration options common to all sub-projects/modules.
-
 buildscript {
     ext.kotlin_version = '1.2.51'
     ext.support_library_version = '27.1.1'

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext.support_library_version = '27.1.1'
     ext.constraint_version = '1.1.2'
     ext.room_version = '1.1.1'
-    ext.dagger_version = '2.14.1'
+    ext.dagger_version = '2.15'
     ext.lifecycle_version = '1.1.1'
     ext.dataBinding_version = '3.1.4'
     ext.ktx_version = '0.3'


### PR DESCRIPTION
#14 

+ BitriseのPR-workflowからslack通知ステップを外した
   + Bitriseの`public app`では`Secrets`をPRから見られないため
   + 当レポジトリもpublicなので、Bitriseでもpublic appで進める
+ Unit Testの失敗は別Issue(#1 )で対応

[Public Appについて](https://devcenter.bitrise.io/getting-started/adding-a-new-app/public-apps/)